### PR TITLE
Fix FutureWarning for dtype

### DIFF
--- a/hub_audit.py
+++ b/hub_audit.py
@@ -237,9 +237,10 @@ def read_inventory(path):
                     'Additional information (optional)': 'Notes'}, axis=1)
 
     # Adds new columns for recording errors found during the audit, one for each error type.
-    df_inventory['Audit_Dates'] = np.nan
-    df_inventory['Audit_Inventory'] = np.nan
-    df_inventory['Audit_Required'] = np.nan
+    # Initial values are TBD, so they can be updated with the results later without a dtype FutureWarning
+    df_inventory['Audit_Dates'] = 'TBD'
+    df_inventory['Audit_Inventory'] = 'TBD'
+    df_inventory['Audit_Required'] = 'TBD'
 
     return df_inventory
 

--- a/hub_audit.py
+++ b/hub_audit.py
@@ -134,8 +134,8 @@ def check_required(df_inventory):
     for column_name in required:
         df_inventory.loc[pd.isna(df_inventory[column_name]), 'Audit_Required'] = 'Missing'
 
-    # Updates the value of any cells that are still blank (have no errors) with "Correct".
-    df_inventory['Audit_Required'] = df_inventory['Audit_Required'].fillna('Correct')
+    # Updates the value of any cells that are still TBD (have no errors) with "Correct".
+    df_inventory.loc[df_inventory['Audit_Required'] == 'TBD', 'Audit_Required'] = 'Correct'
 
     return df_inventory
 

--- a/hub_audit.py
+++ b/hub_audit.py
@@ -74,8 +74,8 @@ def check_dates(df_inventory):
     df_inventory = pd.concat([df_date, df_nondate])
     df_inventory = df_inventory.sort_values(['Share', 'Folder'])
 
-    # Updates the value of any cells that are still blank (have no errors) with "Correct".
-    df_inventory['Audit_Dates'] = df_inventory['Audit_Dates'].fillna('Correct')
+    # Updates the value of any cells that are still 'TBD' (have no errors) with "Correct".
+    df_inventory.loc[df_inventory['Audit_Dates'] == 'TBD', 'Audit_Dates'] = 'Correct'
 
     return df_inventory
 

--- a/hub_audit.py
+++ b/hub_audit.py
@@ -105,8 +105,8 @@ def check_inventory(df_inventory, df_shares):
     df_inventory.loc[df_inventory['_merge'] == 'left_only', 'Audit_Inventory'] = 'Not in share'
     df_inventory.loc[df_inventory['_merge'] == 'right_only', 'Audit_Inventory'] = 'Not in inventory'
 
-    # Updates the value of any cells that are still blank (have no errors) with "Correct".
-    df_inventory['Audit_Inventory'] = df_inventory['Audit_Inventory'].fillna('Correct')
+    # Updates the value of any cells that are still TBD (have no errors) with "Correct".
+    df_inventory.loc[df_inventory['Audit_Inventory'] == 'TBD', 'Audit_Inventory'] = 'Correct'
 
     # Cleans up and returns the dataframe.
     # The temporary column '_merge' is removed and the rows are sorted.

--- a/tests/test_check_dates.py
+++ b/tests/test_check_dates.py
@@ -28,21 +28,21 @@ class MyTestCase(unittest.TestCase):
     def test_combination(self):
         """Test for an inventory where the date formatting is mixed"""
         # Make a dataframe with Hub inventory data and run the function being tested.
-        rows = [['Share_A', 'A1', 'Backlog', 'June', 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                ['Share_A', 'A2', 'Backlog', 'June', datetime(2021, 1, 1, 0, 0), NaN, NaN, NaN, NaN, NaN],
-                ['Share_B', 'B', 'Backlog', 'June', '6 months', NaN, NaN, NaN, NaN, NaN],
-                ['Share_C', 'C1', 'Backlog', 'June', datetime(3031, 12, 14, 0, 0), NaN, NaN, NaN, NaN, NaN],
-                ['Share_C', 'C2', 'Backlog', 'June', 'permanent', NaN, NaN, NaN, NaN, NaN]]
+        rows = [['Share_A', 'A1', 'Backlog', 'June', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share_A', 'A2', 'Backlog', 'June', datetime(2021, 1, 1, 0, 0), NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share_B', 'B', 'Backlog', 'June', '6 months', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share_C', 'C1', 'Backlog', 'June', datetime(3031, 12, 14, 0, 0), NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share_C', 'C2', 'Backlog', 'June', 'permanent', NaN, NaN, 'TBD', 'TBD', 'TBD']]
         inventory_df = check_dates(DataFrame(rows, columns=self.columns))
 
         # Tests if the resulting dataframe has the expected data.
         result = df_to_list(inventory_df)
         expected = [self.columns,
-                    ['Share_A', 'A1', 'Backlog', 'June', 'Permanent', 'nan', 'nan', 'Correct', 'nan', 'nan'],
-                    ['Share_A', 'A2', 'Backlog', 'June', datetime(2021, 1, 1, 0, 0), 'nan', 'nan', 'Expired', 'nan', 'nan'],
-                    ['Share_B', 'B', 'Backlog', 'June', '6 months', 'nan', 'nan', 'Review', 'nan', 'nan'],
-                    ['Share_C', 'C1', 'Backlog', 'June', datetime(3031, 12, 14, 0, 0), 'nan', 'nan', 'Correct', 'nan', 'nan'],
-                    ['Share_C', 'C2', 'Backlog', 'June', 'permanent', 'nan', 'nan', 'Correct', 'nan', 'nan']]
+                    ['Share_A', 'A1', 'Backlog', 'June', 'Permanent', 'nan', 'nan', 'Correct', 'TBD', 'TBD'],
+                    ['Share_A', 'A2', 'Backlog', 'June', datetime(2021, 1, 1, 0, 0), 'nan', 'nan', 'Expired', 'TBD', 'TBD'],
+                    ['Share_B', 'B', 'Backlog', 'June', '6 months', 'nan', 'nan', 'Review', 'TBD', 'TBD'],
+                    ['Share_C', 'C1', 'Backlog', 'June', datetime(3031, 12, 14, 0, 0), 'nan', 'nan', 'Correct', 'TBD', 'TBD'],
+                    ['Share_C', 'C2', 'Backlog', 'June', 'permanent', 'nan', 'nan', 'Correct', 'TBD', 'TBD']]
         self.assertEqual(result, expected, "Problem with test for combined date formats")
 
     def test_dates_expired(self):
@@ -51,68 +51,65 @@ class MyTestCase(unittest.TestCase):
         Still working on what is causing that problem - see Issue 5.
         """
         # Make a dataframe with Hub inventory data and run the function being tested.
-        rows = [['Share_A', 'A1', 'Backlog', 'June', datetime(2001, 1, 1, 0, 0), NaN, NaN, NaN, NaN, NaN],
-                ['Share_A', 'A2', 'Backlog', 'June', datetime(2021, 1, 1, 0, 0), NaN, NaN, NaN, NaN, NaN],
-                ['Share_C', 'C1', 'Backlog', 'June', datetime(2931, 12, 14, 0, 0), NaN, NaN, NaN, NaN, NaN]]
+        rows = [['Share_A', 'A1', 'Backlog', 'June', datetime(2001, 1, 1, 0, 0), NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share_A', 'A2', 'Backlog', 'June', datetime(2021, 1, 1, 0, 0), NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share_C', 'C1', 'Backlog', 'June', datetime(2931, 12, 14, 0, 0), NaN, NaN, 'TBD', 'TBD', 'TBD']]
         inventory_df = check_dates(DataFrame(rows, columns=self.columns))
 
         # Tests if the resulting dataframe has the expected data.
         result = df_to_list(inventory_df)
         expected = [self.columns,
-                    ['Share_A', 'A1', 'Backlog', 'June', datetime(2001, 1, 1, 0, 0), 'nan', 'nan', 'Expired', 'nan',
-                     'nan'],
-                    ['Share_A', 'A2', 'Backlog', 'June', datetime(2021, 1, 1, 0, 0), 'nan', 'nan', 'Expired', 'nan',
-                     'nan'],
-                    ['Share_C', 'C1', 'Backlog', 'June', datetime(2931, 12, 14, 0, 0), 'nan', 'nan', 'Correct', 'nan',
-                     'nan']]
+                    ['Share_A', 'A1', 'Backlog', 'June', datetime(2001, 1, 1, 0, 0), 'nan', 'nan', 'Expired', 'TBD', 'TBD'],
+                    ['Share_A', 'A2', 'Backlog', 'June', datetime(2021, 1, 1, 0, 0), 'nan', 'nan', 'Expired', 'TBD', 'TBD'],
+                    ['Share_C', 'C1', 'Backlog', 'June', datetime(2931, 12, 14, 0, 0), 'nan', 'nan', 'Correct', 'TBD', 'TBD']]
         self.assertEqual(result, expected, "Problem with test for dates, expired")
 
     def test_dates_future(self):
         """Test for an inventory where the dates are formatted as a date and the dates are in the future"""
         # Make a dataframe with Hub inventory data and run the function being tested.
-        rows = [['Share_A', 'A1', 'Backlog', 'June', datetime(2122, 10, 15, 0, 0), NaN, NaN, NaN, NaN, NaN],
-                ['Share_A', 'A2', 'Backlog', 'June', datetime(2222, 10, 15, 0, 0), NaN, NaN, NaN, NaN, NaN],
-                ['Share_B', 'B', 'Backlog', 'June', datetime(2322, 10, 15, 0, 0), NaN, NaN, NaN, NaN, NaN]]
+        rows = [['Share_A', 'A1', 'Backlog', 'June', datetime(2122, 10, 15, 0, 0), NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share_A', 'A2', 'Backlog', 'June', datetime(2222, 10, 15, 0, 0), NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share_B', 'B', 'Backlog', 'June', datetime(2322, 10, 15, 0, 0), NaN, NaN, 'TBD', 'TBD', 'TBD']]
         inventory_df = check_dates(DataFrame(rows, columns=self.columns))
 
         # Tests if the resulting dataframe has the expected data.
         result = df_to_list(inventory_df)
         expected = [self.columns,
-                    ['Share_A', 'A1', 'Backlog', 'June', datetime(2122, 10, 15, 0, 0), 'nan', 'nan', 'Correct', 'nan', 'nan'],
-                    ['Share_A', 'A2', 'Backlog', 'June', datetime(2222, 10, 15, 0, 0), 'nan', 'nan', 'Correct', 'nan', 'nan'],
-                    ['Share_B', 'B', 'Backlog', 'June', datetime(2322, 10, 15, 0, 0), 'nan', 'nan', 'Correct', 'nan', 'nan']]
+                    ['Share_A', 'A1', 'Backlog', 'June', datetime(2122, 10, 15, 0, 0), 'nan', 'nan', 'Correct', 'TBD', 'TBD'],
+                    ['Share_A', 'A2', 'Backlog', 'June', datetime(2222, 10, 15, 0, 0), 'nan', 'nan', 'Correct', 'TBD', 'TBD'],
+                    ['Share_B', 'B', 'Backlog', 'June', datetime(2322, 10, 15, 0, 0), 'nan', 'nan', 'Correct', 'TBD', 'TBD']]
         self.assertEqual(result, expected, "Problem with test for dates, future")
 
     def test_strings_not_permanent(self):
         """Test for an inventory where the dates are a string but not 'permanent' or 'Permanent'"""
         # Make a dataframe with Hub inventory data and run the function being tested.
-        rows = [['Share_A', 'A1', 'Backlog', 'June', '6 months', NaN, NaN, NaN, NaN, NaN],
-                ['Share_A', 'A2', 'Backlog', 'June', 'year', NaN, NaN, NaN, NaN, NaN],
-                ['Share_B', 'B', 'Backlog', 'June', 'In folder title', NaN, NaN, NaN, NaN, NaN]]
+        rows = [['Share_A', 'A1', 'Backlog', 'June', '6 months', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share_A', 'A2', 'Backlog', 'June', 'year', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share_B', 'B', 'Backlog', 'June', 'In folder title', NaN, NaN, 'TBD', 'TBD', 'TBD']]
         inventory_df = check_dates(DataFrame(rows, columns=self.columns))
 
         # Tests if the resulting dataframe has the expected data.
         result = df_to_list(inventory_df)
         expected = [self.columns,
-                    ['Share_A', 'A1', 'Backlog', 'June', '6 months', 'nan', 'nan', 'Review', 'nan', 'nan'],
-                    ['Share_A', 'A2', 'Backlog', 'June', 'year', 'nan', 'nan', 'Review', 'nan', 'nan'],
-                    ['Share_B', 'B', 'Backlog', 'June', 'In folder title', 'nan', 'nan', 'Review', 'nan', 'nan']]
+                    ['Share_A', 'A1', 'Backlog', 'June', '6 months', 'nan', 'nan', 'Review', 'TBD', 'TBD'],
+                    ['Share_A', 'A2', 'Backlog', 'June', 'year', 'nan', 'nan', 'Review', 'TBD', 'TBD'],
+                    ['Share_B', 'B', 'Backlog', 'June', 'In folder title', 'nan', 'nan', 'Review', 'TBD', 'TBD']]
         self.assertEqual(result, expected, "Problem with test for strings, not permanent")
 
     def test_strings_permanent(self):
         """Test for an inventory where the dates are either 'permanent' or 'Permanent'"""
         # Make a dataframe with Hub inventory data and run the function being tested.
-        rows = [['Share_A', 'A1', 'Backlog', 'June', 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                ['Share_A', 'A2', 'Backlog', 'June', 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                ['Share_B', 'B', 'Backlog', 'June', 'permanent', NaN, NaN, NaN, NaN, NaN]]
+        rows = [['Share_A', 'A1', 'Backlog', 'June', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share_A', 'A2', 'Backlog', 'June', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share_B', 'B', 'Backlog', 'June', 'permanent', NaN, NaN, 'TBD', 'TBD', 'TBD']]
         inventory_df = check_dates(DataFrame(rows, columns=self.columns))
 
         # Tests if the resulting dataframe has the expected data.
         result = df_to_list(inventory_df)
         expected = [self.columns,
-                    ['Share_A', 'A1', 'Backlog', 'June', 'Permanent', 'nan', 'nan', 'Correct', 'nan', 'nan'],
-                    ['Share_A', 'A2', 'Backlog', 'June', 'Permanent', 'nan', 'nan', 'Correct', 'nan', 'nan'],
-                    ['Share_B', 'B', 'Backlog', 'June', 'permanent', 'nan', 'nan', 'Correct', 'nan', 'nan']]
+                    ['Share_A', 'A1', 'Backlog', 'June', 'Permanent', 'nan', 'nan', 'Correct', 'TBD', 'TBD'],
+                    ['Share_A', 'A2', 'Backlog', 'June', 'Permanent', 'nan', 'nan', 'Correct', 'TBD', 'TBD'],
+                    ['Share_B', 'B', 'Backlog', 'June', 'permanent', 'nan', 'nan', 'Correct', 'TBD', 'TBD']]
         self.assertEqual(result, expected, "Problem with test for strings, permanent")
 
 

--- a/tests/test_check_inventory.py
+++ b/tests/test_check_inventory.py
@@ -6,7 +6,6 @@ To simply testing, the inventory df only includes columns needed for the compari
 import unittest
 from hub_audit import check_inventory
 from numpy import NaN
-from os.path import join
 from pandas import DataFrame
 
 
@@ -22,10 +21,10 @@ class MyTestCase(unittest.TestCase):
     def test_match(self):
         """Test for when the inventory matches the share contents"""
         # Makes variables for function input and run the function being tested.
-        inventory_df = DataFrame([['share_a', 'folder_a', NaN],
-                                  ['share_a', 'file.txt', NaN],
-                                  ['share_b', 'folder_b\\folder_b1', NaN],
-                                  ['share_c', 'born-digital\\closed\\folder', NaN]],
+        inventory_df = DataFrame([['share_a', 'folder_a', 'TBD'],
+                                  ['share_a', 'file.txt', 'TBD'],
+                                  ['share_b', 'folder_b\\folder_b1', 'TBD'],
+                                  ['share_c', 'born-digital\\closed\\folder', 'TBD']],
                                  columns=['Share', 'Folder', 'Audit_Inventory'])
         shares_df = DataFrame([['share_a', 'folder_a'],
                                ['share_a', 'file.txt'],
@@ -46,10 +45,10 @@ class MyTestCase(unittest.TestCase):
     def test_match_duplicates(self):
         """Test for when the inventory matches the share contents, which has duplicate rows"""
         # Makes variables for function input and run the function being tested.
-        inventory_df = DataFrame([['share_a', 'folder_a', NaN],
-                                  ['share_a', 'file.txt', NaN],
-                                  ['share_b', 'folder_b\\folder_b1', NaN],
-                                  ['share_c', 'born-digital\\closed\\folder', NaN]],
+        inventory_df = DataFrame([['share_a', 'folder_a', 'TBD'],
+                                  ['share_a', 'file.txt', 'TBD'],
+                                  ['share_b', 'folder_b\\folder_b1', 'TBD'],
+                                  ['share_c', 'born-digital\\closed\\folder', 'TBD']],
                                  columns=['Share', 'Folder', 'Audit_Inventory'])
         shares_df = DataFrame([['share_a', 'folder_a'],
                                ['share_a', 'folder_a'],
@@ -73,8 +72,8 @@ class MyTestCase(unittest.TestCase):
     def test_not_inventory(self):
         """Test for when some rows are only in the share and not the inventory"""
         # Makes variables for function input and run the function being tested.
-        inventory_df = DataFrame([['share_a', 'folder_a', NaN],
-                                  ['share_a', 'file.txt', NaN]],
+        inventory_df = DataFrame([['share_a', 'folder_a', 'TBD'],
+                                  ['share_a', 'file.txt', 'TBD']],
                                  columns=['Share', 'Folder', 'Audit_Inventory'])
         shares_df = DataFrame([['share_a', 'file.txt'],
                                ['share_a', 'folder_a'],
@@ -97,11 +96,11 @@ class MyTestCase(unittest.TestCase):
     def test_not_share(self):
         """Test for when some rows are only in the inventory and not the share"""
         # Makes variables for function input and run the function being tested.
-        inventory_df = DataFrame([['share_a', 'born-digital\\closed\\folder', NaN],
-                                  ['share_a', 'folder_a', NaN],
-                                  ['share_a', 'file.txt', NaN],
-                                  ['share_b', 'folder_b\\folder_b1', NaN],
-                                  ['share_c', 'born-digital\\closed\\folder', NaN]],
+        inventory_df = DataFrame([['share_a', 'born-digital\\closed\\folder', 'TBD'],
+                                  ['share_a', 'folder_a', 'TBD'],
+                                  ['share_a', 'file.txt', 'TBD'],
+                                  ['share_b', 'folder_b\\folder_b1', 'TBD'],
+                                  ['share_c', 'born-digital\\closed\\folder', 'TBD']],
                                  columns=['Share', 'Folder', 'Audit_Inventory'])
         shares_df = DataFrame([['share_a', 'folder_a'],
                                ['share_c', 'born-digital\\closed\\folder']],
@@ -121,9 +120,9 @@ class MyTestCase(unittest.TestCase):
     def test_variety(self):
         """Test for when some rows are just in the inventory, some just in the share, and some match"""
         # Makes variables for function input and run the function being tested.
-        inventory_df = DataFrame([['share_c', 'born-digital\\closed\\folder', NaN],
-                                  ['share_a', 'folder_a', NaN],
-                                  ['share_a', 'file.txt', NaN]],
+        inventory_df = DataFrame([['share_c', 'born-digital\\closed\\folder', 'TBD'],
+                                  ['share_a', 'folder_a', 'TBD'],
+                                  ['share_a', 'file.txt', 'TBD']],
                                  columns=['Share', 'Folder', 'Audit_Inventory'])
         shares_df = DataFrame([['share_a', 'folder_a'],
                                ['share_b', 'file.txt'],

--- a/tests/test_check_required.py
+++ b/tests/test_check_required.py
@@ -27,113 +27,113 @@ class MyTestCase(unittest.TestCase):
     def test_complete(self):
         """Test for an inventory with data in all required columns"""
         # Make a dataframe with Hub inventory data and run the function being tested.
-        rows = [['Share', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                ['Share', 'Folder2', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                ['Share', 'Folder3', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN]]
+        rows = [['Share', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share', 'Folder2', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share', 'Folder3', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD']]
         inventory_df = check_required(DataFrame(rows, columns=self.columns))
 
         # Tests if the resulting dataframe has the expected data.
         result = df_to_list(inventory_df)
         expected = [self.columns,
-                    ['Share', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Correct'],
-                    ['Share', 'Folder2', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Correct'],
-                    ['Share', 'Folder3', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Correct']]
+                    ['Share', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Correct'],
+                    ['Share', 'Folder2', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Correct'],
+                    ['Share', 'Folder3', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Correct']]
         self.assertEqual(result, expected, "Problem with test for complete data")
 
     def test_missing_combination(self):
         """Test for an inventory missing data in multiple required columns"""
         # Make a dataframe with Hub inventory data and run the function being tested.
-        rows = [[NaN, NaN, 'Medium Priority', NaN, 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                [NaN, NaN, NaN, NaN, NaN, NaN, NaN, 'Note', NaN, NaN],
-                ['Share', 'Folder3', NaN, 'Bill', NaN, NaN, NaN, NaN, NaN, NaN]]
+        rows = [[NaN, NaN, 'Medium Priority', NaN, 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                [NaN, NaN, NaN, NaN, NaN, 'Note', NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share', 'Folder3', NaN, 'Bill', NaN, NaN, NaN, 'TBD', 'TBD', 'TBD']]
         inventory_df = check_required(DataFrame(rows, columns=self.columns))
 
         # Tests if the resulting dataframe has the expected data.
         result = df_to_list(inventory_df)
         expected = [self.columns,
-                    ['nan', 'nan', 'Medium Priority', 'nan', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Missing'],
-                    ['nan', 'nan', 'nan', 'nan', 'nan', 'nan', 'nan', 'Note', 'nan', 'Missing'],
-                    ['Share', 'Folder3', 'nan', 'Bill', 'nan', 'nan', 'nan', 'nan', 'nan', 'Missing']]
+                    ['nan', 'nan', 'Medium Priority', 'nan', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Missing'],
+                    ['nan', 'nan', 'nan', 'nan', 'nan', 'Note', 'nan', 'TBD', 'TBD', 'Missing'],
+                    ['Share', 'Folder3', 'nan', 'Bill', 'nan', 'nan', 'nan', 'TBD', 'TBD', 'Missing']]
         self.assertEqual(result, expected, "Problem with test for missing combinations of required columns")
 
     def test_missing_date(self):
         """Test for an inventory missing data in the "Date to review for deletion" column"""
         # Make a dataframe with Hub inventory data and run the function being tested.
-        rows = [['Share', 'Folder1', 'Medium Priority', 'Bill', NaN, NaN, NaN, NaN, NaN, NaN],
-                ['Share', 'Folder2', 'Medium Priority', 'Bill', NaN, NaN, NaN, NaN, NaN, NaN],
-                ['Share', 'Folder3', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN]]
+        rows = [['Share', 'Folder1', 'Medium Priority', 'Bill', NaN, NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share', 'Folder2', 'Medium Priority', 'Bill', NaN, NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share', 'Folder3', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD']]
         inventory_df = check_required(DataFrame(rows, columns=self.columns))
 
         # Tests if the resulting dataframe has the expected data.
         result = df_to_list(inventory_df)
         expected = [self.columns,
-                    ['Share', 'Folder1', 'Medium Priority', 'Bill', 'nan', 'nan', 'nan', 'nan', 'nan', 'Missing'],
-                    ['Share', 'Folder2', 'Medium Priority', 'Bill', 'nan', 'nan', 'nan', 'nan', 'nan', 'Missing'],
-                    ['Share', 'Folder3', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Correct']]
+                    ['Share', 'Folder1', 'Medium Priority', 'Bill', 'nan', 'nan', 'nan', 'TBD', 'TBD', 'Missing'],
+                    ['Share', 'Folder2', 'Medium Priority', 'Bill', 'nan', 'nan', 'nan', 'TBD', 'TBD', 'Missing'],
+                    ['Share', 'Folder3', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Correct']]
         self.assertEqual(result, expected, "Problem with test for missing date to review for deletion")
 
     def test_missing_folder(self):
         """Test for an inventory missing data in the "Folder Name" column"""
         # Make a dataframe with Hub inventory data and run the function being tested.
-        rows = [['Share', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                ['Share', NaN, 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                ['Share', NaN, 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN]]
+        rows = [['Share', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share', NaN, 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share', NaN, 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD']]
         inventory_df = check_required(DataFrame(rows, columns=self.columns))
 
         # Tests if the resulting dataframe has the expected data.
         result = df_to_list(inventory_df)
         expected = [self.columns,
-                    ['Share', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Correct'],
-                    ['Share', 'nan', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Missing'],
-                    ['Share', 'nan', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Missing']]
+                    ['Share', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Correct'],
+                    ['Share', 'nan', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Missing'],
+                    ['Share', 'nan', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Missing']]
         self.assertEqual(result, expected, "Problem with test for missing folder name")
 
     def test_missing_person(self):
         """Test for an inventory missing data in the "Person Responsible" column"""
         # Make a dataframe with Hub inventory data and run the function being tested.
-        rows = [['Share', 'Folder1', 'Medium Priority', NaN, 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                ['Share', 'Folder2', 'Medium Priority', NaN, 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                ['Share', 'Folder3', 'Medium Priority', NaN, 'Permanent', NaN, NaN, NaN, NaN, NaN]]
+        rows = [['Share', 'Folder1', 'Medium Priority', NaN, 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share', 'Folder2', 'Medium Priority', NaN, 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share', 'Folder3', 'Medium Priority', NaN, 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD']]
         inventory_df = check_required(DataFrame(rows, columns=self.columns))
 
         # Tests if the resulting dataframe has the expected data.
         result = df_to_list(inventory_df)
         expected = [self.columns,
-                    ['Share', 'Folder1', 'Medium Priority', 'nan', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Missing'],
-                    ['Share', 'Folder2', 'Medium Priority', 'nan', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Missing'],
-                    ['Share', 'Folder3', 'Medium Priority', 'nan', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Missing']]
+                    ['Share', 'Folder1', 'Medium Priority', 'nan', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Missing'],
+                    ['Share', 'Folder2', 'Medium Priority', 'nan', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Missing'],
+                    ['Share', 'Folder3', 'Medium Priority', 'nan', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Missing']]
         self.assertEqual(result, expected, "Problem with test for missing person responsible")
 
     def test_missing_share(self):
         """Test for an inventory missing data in the "Share" column"""
         # Make a dataframe with Hub inventory data and run the function being tested.
-        rows = [[NaN, 'Folder1', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                ['Share', 'Folder2', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                [NaN, 'Folder3', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN]]
+        rows = [[NaN, 'Folder1', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share', 'Folder2', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                [NaN, 'Folder3', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD']]
         inventory_df = check_required(DataFrame(rows, columns=self.columns))
 
         # Tests if the resulting dataframe has the expected data.
         result = df_to_list(inventory_df)
         expected = [self.columns,
-                    ['nan', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Missing'],
-                    ['Share', 'Folder2', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Correct'],
-                    ['nan', 'Folder3', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Missing']]
+                    ['nan', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Missing'],
+                    ['Share', 'Folder2', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Correct'],
+                    ['nan', 'Folder3', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Missing']]
         self.assertEqual(result, expected, "Problem with test for missing share")
 
     def test_missing_use(self):
         """Test for an inventory missing data in the "Use Policy Category" column"""
         # Make a dataframe with Hub inventory data and run the function being tested.
-        rows = [['Share', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                ['Share', 'Folder2', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN],
-                ['Share', 'Folder3', NaN, 'Bill', 'Permanent', NaN, NaN, NaN, NaN, NaN]]
+        rows = [['Share', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share', 'Folder2', 'Medium Priority', 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD'],
+                ['Share', 'Folder3', NaN, 'Bill', 'Permanent', NaN, NaN, 'TBD', 'TBD', 'TBD']]
         inventory_df = check_required(DataFrame(rows, columns=self.columns))
 
         # Tests if the resulting dataframe has the expected data.
         result = df_to_list(inventory_df)
         expected = [self.columns,
-                    ['Share', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Correct'],
-                    ['Share', 'Folder2', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Correct'],
-                    ['Share', 'Folder3', 'nan', 'Bill', 'Permanent', 'nan', 'nan', 'nan', 'nan', 'Missing']]
+                    ['Share', 'Folder1', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Correct'],
+                    ['Share', 'Folder2', 'Medium Priority', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Correct'],
+                    ['Share', 'Folder3', 'nan', 'Bill', 'Permanent', 'nan', 'nan', 'TBD', 'TBD', 'Missing']]
         self.assertEqual(result, expected, "Problem with test for missing use policy category")
 
 

--- a/tests/test_read_inventory.py
+++ b/tests/test_read_inventory.py
@@ -19,9 +19,9 @@ class MyTestCase(unittest.TestCase):
         result = [result.columns.tolist()] + result.values.tolist()
         expected = [['Share', 'Folder', 'Use', 'Responsible', 'Review_Date', 'Notes',
                      'Audit_Dates', 'Audit_Inventory', 'Audit_Required'],
-                    ['digital_ingest', 'alston01', 'Backlog', 'Callie', datetime(2023, 9, 30), '', '', '', ''],
-                    ['digital_ingest', 'alston03', 'Backlog', 'Callie', datetime(2023, 9, 30), '', '', '', ''],
-                    ['mezzanine_1', 'mezzanine_1', 'Access/Mezzanine', 'Callie', 'permanent', '', '', '', '']]
+                    ['digital_ingest', 'alston01', 'Backlog', 'Callie', datetime(2023, 9, 30), '', 'TBD', 'TBD', 'TBD'],
+                    ['digital_ingest', 'alston03', 'Backlog', 'Callie', datetime(2023, 9, 30), '', 'TBD', 'TBD', 'TBD'],
+                    ['mezzanine_1', 'mezzanine_1', 'Access/Mezzanine', 'Callie', 'permanent', '', 'TBD', 'TBD', 'TBD']]
         self.assertEqual(result, expected, "Problem with test for blank rows")
 
     def test_deletions(self):
@@ -34,10 +34,10 @@ class MyTestCase(unittest.TestCase):
         result = [result.columns.tolist()] + result.values.tolist()
         expected = [['Share', 'Folder', 'Use', 'Responsible', 'Review_Date', 'Notes',
                      'Audit_Dates', 'Audit_Inventory', 'Audit_Required'],
-                    ['Dig Stew', 'AIT\\2024-02', 'Backlog', 'Adriane', '3 months', '', '', '', ''],
-                    ['Dig Stew', 'Topic_Modeling', 'Working Files', 'Adriane', datetime(2025, 1, 31), '', '', '', ''],
-                    ['DLG_TWO', 'curation\\athens', 'Backlog', 'Donnie', datetime(2024, 8, 3, 0, 0), '', '', '', ''],
-                    ['DLG_TWO', 'curation\\atlanta', 'Backlog', 'Donnie', datetime(2024, 8, 10, 0, 0), '', '', '', '']]
+                    ['Dig Stew', 'AIT\\2024-02', 'Backlog', 'Adriane', '3 months', '', 'TBD', 'TBD', 'TBD'],
+                    ['Dig Stew', 'Topic_Modeling', 'Working Files', 'Adriane', datetime(2025, 1, 31), '', 'TBD', 'TBD', 'TBD'],
+                    ['DLG_TWO', 'curation\\athens', 'Backlog', 'Donnie', datetime(2024, 8, 3, 0, 0), '', 'TBD', 'TBD', 'TBD'],
+                    ['DLG_TWO', 'curation\\atlanta', 'Backlog', 'Donnie', datetime(2024, 8, 10, 0, 0), '', 'TBD', 'TBD', 'TBD']]
         self.assertEqual(result, expected, "Problem with test for deletions")
 
     def test_usual(self):
@@ -49,12 +49,12 @@ class MyTestCase(unittest.TestCase):
         result = [result.columns.tolist()] + result.values.tolist()
         expected = [['Share', 'Folder', 'Use', 'Responsible', 'Review_Date', 'Notes',
                      'Audit_Dates', 'Audit_Inventory', 'Audit_Required'],
-                    ['Hargrett', 'Access\\ms1234', 'Access/Mezzanine',  'Emmeline', 'Permanent', 'Redacted', '', '', ''],
-                    ['Hargrett', 'Access\\Kiosk', 'Access/Mezzanine', 'Emmeline', 'Permanent', '', '', '', ''],
-                    ['Hargrett', 'Oral history temp', 'Transfer', 'Steve', '6 months after creation', '', '', '', ''],
-                    ['MAGIL_GGP', 'Legislative docs', 'Transfer', 'Sarah', datetime(2024, 7, 1,0, 0), 'Pilot', '', '', ''],
-                    ['SCL_Imaging_Lab', 'backlog', 'Backlog', 'Chris', datetime(2024, 6, 1, 0, 0), '', '', '', ''],
-                    ['SCL_Imaging_Lab', 'tiffs', 'Medium Priority', 'Mary', 'Permanent', '', '', '', '']]
+                    ['Hargrett', 'Access\\ms1234', 'Access/Mezzanine',  'Emmeline', 'Permanent', 'Redacted', 'TBD', 'TBD', 'TBD'],
+                    ['Hargrett', 'Access\\Kiosk', 'Access/Mezzanine', 'Emmeline', 'Permanent', '', 'TBD', 'TBD', 'TBD'],
+                    ['Hargrett', 'Oral history temp', 'Transfer', 'Steve', '6 months after creation', '', 'TBD', 'TBD', 'TBD'],
+                    ['MAGIL_GGP', 'Legislative docs', 'Transfer', 'Sarah', datetime(2024, 7, 1,0, 0), 'Pilot', 'TBD', 'TBD', 'TBD'],
+                    ['SCL_Imaging_Lab', 'backlog', 'Backlog', 'Chris', datetime(2024, 6, 1, 0, 0), '', 'TBD', 'TBD', 'TBD'],
+                    ['SCL_Imaging_Lab', 'tiffs', 'Medium Priority', 'Mary', 'Permanent', '', 'TBD', 'TBD', 'TBD']]
         self.assertEqual(result, expected, "Problem with test for usual")
 
 


### PR DESCRIPTION
Start the three audit columns with a default value of "TBD", instead of blank, so that the columns are already strings. Then they can be updated with the audit results (also strings) by the three checking functions without a warning.